### PR TITLE
Fixs hardcoded ticketIDPattern from findJiraInCommit()

### DIFF
--- a/src/Jira.js
+++ b/src/Jira.js
@@ -55,7 +55,7 @@ export default class Jira {
    */
   findJiraInCommit(commitLog, releaseVersion) {
     const log = Object.assign({tickets: []}, commitLog);
-    const ticketPattern = /[a-zA-Z]+\-[0-9]+/;
+    const ticketPattern = this.config.jira.ticketIDPattern.source;
     const promises = [Promise.resolve()];
     const found = [];
 


### PR DESCRIPTION
There's a bug when you change the `ticketIDPattern` from `changelog.config.js` the method `findJiraInCommit()` won't be aware of it and will provoke a fatal issue. This PR fixs that