### PR TITLE
Fix wrong exported Jira class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,6 @@
 // Jira Changelog API
 module.exports = {
   SourceControl: require('./SourceControl').default,
-  Jira: require('./JiraChangelog').default,
+  Jira: require('./Jira').default,
   Config: require('./Config')
 };


### PR DESCRIPTION
I think this is what is causing of getting an outdated/non-existence JiraChangelog class when you require the library as a module
