### PR TITLE
Don't use symmetric comparison between branches

### DIFF
--- a/src/SourceControl.js
+++ b/src/SourceControl.js
@@ -65,6 +65,7 @@ export default class SourceControl {
           authorEmail: '%ae',
           parents: '%P'
         },
+        symmetric: false,
         ...range,
       }
 


### PR DESCRIPTION
Hi, thanks for your plugin. I'm trying to use it, but I was having a hard time since the plugin was only identifying 2 or 3 commits of difference between two branches while it should have found around 80.
Digging the code, and also the `simple-git` plugin code, I've found that by not passing anything in the `opts.symmetric` option we are actually getting the commits present on each branch that are not present on both branches. Everything works if the branches have the same commit history, and only one of the branches has extra commits. If both branches have different commit histories, then when we try to build the logs from the graph something goes really wrong and my 80 commits are reduced to 3.

I really think that we don't want to use the symmetric comparison. More info here https://stackoverflow.com/questions/462974/what-are-the-differences-between-double-dot-and-triple-dot-in-git-com

Thanks