### PR TITLE
Possible to set hideEmptyBlocks option.

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -222,6 +222,9 @@ export async function generateTemplateData(config, changelog, releaseVersions) {
     baseUrl: config.jira.baseUrl,
     releaseVersions: releaseVersions,
   };
+  data.options = {
+    hideEmptyBlocks: !!config.hideEmptyBlocks,
+  };
 
   return data;
 }

--- a/src/template.test.js
+++ b/src/template.test.js
@@ -4,8 +4,9 @@ import {
   decorateTicketReverts,
   getTicketReporters,
   groupTicketsByStatus,
-  transformCommitLogs,
+  transformCommitLogs, generateTemplateData, renderTemplate,
 } from './template';
+import {getDefaultConfig} from "./Config";
 
 describe('filter reverts', () => {
   test('the revert commit is removed when the original commit is in the list', () => {
@@ -211,7 +212,7 @@ describe('Get pending tickets', () => {
 });
 
 // Pull it all together
-test('transfor commit logs into template data', () => {
+test('transform commit logs into template data', () => {
   const createTicket = (key, reporter, status) => (
     {
       key,
@@ -283,4 +284,26 @@ test('transfor commit logs into template data', () => {
   expect(tickets.pending.length).toBe(4);
   expect(tickets.pendingByOwner.length).toBe(3);
   expect(tickets.reverted.length).toBe(2);
+});
+
+test('hideEmptyBlocks with false', async () => {
+  const config = {
+    ...getDefaultConfig(),
+    hideEmptyBlocks: false,
+  };
+  const templateData = await generateTemplateData(config, [], []);
+  const templateRendered = renderTemplate(config, templateData);
+
+  expect(templateRendered).toContain('~ None ~');
+});
+
+test('hideEmptyBlocks with true', async () => {
+  const config = {
+    ...getDefaultConfig(),
+    hideEmptyBlocks: true,
+  };
+  const templateData = await generateTemplateData(config, [], []);
+  const templateRendered = renderTemplate(config, templateData);
+
+  expect(templateRendered).not.toContain('~ None ~');
 });


### PR DESCRIPTION
Current release messages (see picture below) contains blocks that can be skipped if empty, so the PR can prevent to take up a space in a web-messenger with new option hideEmptyBlocks.
![image](https://user-images.githubusercontent.com/661654/103133785-fca09b00-46de-11eb-9a4f-57287d412bbb.png)
