### PR TITLE
jira.reporter not required. Ignore finding user instead

### DIFF
--- a/src/Jira.js
+++ b/src/Jira.js
@@ -239,6 +239,8 @@ export default class Jira {
 
     return this.jira.findIssue(ticketId).then((origTicket) => {
       const ticket = Object.assign({}, origTicket);
+      if (!this.config.slack.api || !ticket.fields.reporter)
+        return ticket;
       return this.slack.findUser(ticket.fields.reporter.emailAddress, ticket.fields.reporter.displayName)
       .then((slackUser) => {
         ticket.slackUser = slackUser;

--- a/src/template.js
+++ b/src/template.js
@@ -86,7 +86,7 @@ export function getTicketReporters(tickets) {
   const reporters = {};
 
   tickets.forEach((ticket) => {
-    const { email, displayName } = ticket.fields.reporter;
+    const { email, displayName } = ticket.fields.reporter || [];
     if (!reporters[email]) {
       reporters[email] = {
         email,


### PR DESCRIPTION
If there is no reporter set in jira it was not letting the ticket be processed properly. Received errors of "Ticket XXX not found" and "Cannot destructure property 'email' of 'ticket.fields.reporter' as it is undefined"