### PR TITLE
Provide possibility to use every option available in jira-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module.exports = {
       host: 'myapp.atlassian.net',
       email: 'jirauser@myapp.com',
       token: 'qWoJBdlEp6pJy15fc9tGpsOOR2L5i35v',
-      options: {} // https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions
+      options: {} 
     },
   }
 }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ module.exports = {
 ```
 
 The token is the [API token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) assigned to this user. To see all values supported, look at the [changelog.config.js](https://github.com/jgillick/jira-changelog/blob/master/changelog.config.js) file at the root of this repo.
+Use options object to set [jira-client](https://www.npmjs.com/package/jira-client) options. See [official docs](https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions) for available options.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ module.exports = {
     api: {
       host: 'myapp.atlassian.net',
       email: 'jirauser@myapp.com',
-      token: 'qWoJBdlEp6pJy15fc9tGpsOOR2L5i35v'
+      token: 'qWoJBdlEp6pJy15fc9tGpsOOR2L5i35v',
+      options: {} // https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions
     },
   }
 }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ module.exports = {
 ```
 
 The token is the [API token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) assigned to this user. To see all values supported, look at the [changelog.config.js](https://github.com/jgillick/jira-changelog/blob/master/changelog.config.js) file at the root of this repo.
-Use options object to set [jira-client](https://www.npmjs.com/package/jira-client) options. See [official docs](https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions) for available options.
+
+Use the options object to set [jira-client](https://www.npmjs.com/package/jira-client) options. See [official docs](https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions) for available options.
 
 ## Usage
 

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -15,6 +15,10 @@ module.exports = {
       // Auth token of the user to login with
       // https://confluence.atlassian.com/cloud/api-tokens-938839638.html
       token: undefined,
+      // If you need to set some jira-client option use this object. 
+      // Keep in mind that the properties are prioritized (Using same key in options array would be ignored)
+      // Check jira-client docs for available options: https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions
+      options: {},
     },
 
     // Jira base web URL

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -16,7 +16,6 @@ module.exports = {
       // https://confluence.atlassian.com/cloud/api-tokens-938839638.html
       token: undefined,
       // If you need to set some jira-client option use this object. 
-      // Keep in mind that the properties above are prioritized (Using same key in options array would be ignored)
       // Check jira-client docs for available options: https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions
       options: {},
     },

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -16,7 +16,7 @@ module.exports = {
       // https://confluence.atlassian.com/cloud/api-tokens-938839638.html
       token: undefined,
       // If you need to set some jira-client option use this object. 
-      // Keep in mind that the properties are prioritized (Using same key in options array would be ignored)
+      // Keep in mind that the properties above are prioritized (Using same key in options array would be ignored)
       // Check jira-client docs for available options: https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions
       options: {},
     },

--- a/src/Jira.js
+++ b/src/Jira.js
@@ -38,13 +38,13 @@ export default class Jira {
 
     if (config.jira.api.host) {
       this.jira = new JiraApi({
-        ...options,
         host,
         username: email,
         password: token,
         protocol: 'https',
-        apiVersion: 2,
-        strictSSL: true
+        strictSSL: true,
+        ...options, // let user decide if they need to overwrite any of the hardcoded values (e.g. strictSSL or protocol)
+        apiVersion: 2, // forcing api version 2 to avoid breaking code by using different api version
       });
     } else {
       console.error('ERROR: Cannot configure Jira without a host configuration.');

--- a/src/Jira.js
+++ b/src/Jira.js
@@ -22,7 +22,7 @@ export default class Jira {
     this.ticketPromises = {};
 
     const { host, username, password} = config.jira.api;
-    let { email, token } = config.jira.api;
+    let { email, token, originalOptions } = config.jira.api;
 
     if (!token && typeof password !== 'undefined') {
       console.warn('WARNING: Jira password is deprecated. Use an API token instead.');
@@ -32,9 +32,13 @@ export default class Jira {
       console.warn('WARNING: Jira username is deprecated for API authentication. Use user email instead.');
       email = username
     }
+    if (!originalOptions) {
+      originalOptions = {}
+    }
 
     if (config.jira.api.host) {
       this.jira = new JiraApi({
+        ...originalOptions,
         host,
         username: email,
         password: token,

--- a/src/Jira.js
+++ b/src/Jira.js
@@ -22,7 +22,7 @@ export default class Jira {
     this.ticketPromises = {};
 
     const { host, username, password} = config.jira.api;
-    let { email, token, originalOptions } = config.jira.api;
+    let { email, token, options } = config.jira.api;
 
     if (!token && typeof password !== 'undefined') {
       console.warn('WARNING: Jira password is deprecated. Use an API token instead.');
@@ -32,13 +32,13 @@ export default class Jira {
       console.warn('WARNING: Jira username is deprecated for API authentication. Use user email instead.');
       email = username
     }
-    if (!originalOptions) {
-      originalOptions = {}
+    if (!options) {
+      options = {}
     }
 
     if (config.jira.api.host) {
       this.jira = new JiraApi({
-        ...originalOptions,
+        ...options,
         host,
         username: email,
         password: token,


### PR DESCRIPTION
There are certain cases were one might need to set some jira-client option that is not part of the config api that jira-changelog exposes. 
The company I work in is using a self hosted jira instance which does not support adding API token and username password auth does not work anymore either for me. Only option I had left was creating personal token and using the "bearer" option of jira-client. 
Thats the main reason for this change but I think it would still be good to provide people little bit more control about the configuration if they are forced to use something specific
